### PR TITLE
Options page

### DIFF
--- a/EmbeddedTerminal/BetterBrowser.cs
+++ b/EmbeddedTerminal/BetterBrowser.cs
@@ -108,6 +108,7 @@ namespace EmbeddedTerminal
             var doc = (IHTMLDocument2)browser.Document.DomDocument;
 
             this.styleSheet = doc.createStyleSheet("themesheet.css");
+            doc.createStyleSheet(TermWindowPackage.Instance?.OptionCustomCSSPath??"");
             this.ThemeStyleSheet();
         }
 

--- a/EmbeddedTerminal/EmbeddedTerminal.csproj
+++ b/EmbeddedTerminal/EmbeddedTerminal.csproj
@@ -57,6 +57,9 @@
   <ItemGroup>
     <Compile Include="BetterBrowser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TerminalOptionPage.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="TermWindow.cs" />
     <Compile Include="TermWindowCommand.cs" />
     <Compile Include="TermWindowControl.xaml.cs">

--- a/EmbeddedTerminal/EmbeddedTerminal.csproj
+++ b/EmbeddedTerminal/EmbeddedTerminal.csproj
@@ -72,6 +72,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="view\custom.css">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <Content Include="view\default.css">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/EmbeddedTerminal/TermWindowControl.xaml
+++ b/EmbeddedTerminal/TermWindowControl.xaml
@@ -12,11 +12,6 @@
 	<Grid x:Name="mainGrid">
 		<local:BetterBrowser x:Name="terminalView">
 			<local:BetterBrowser.CustomCSS>
-				<local:CustomCSSRule Selector=".terminal .xterm-color-15">
-					<local:CustomCSSRule.Declarations>
-						<local:CSSDeclaration Attribute="Color" Value="{x:Static platformui:EnvironmentColors.ToolboxContentTextColorKey}" />
-					</local:CustomCSSRule.Declarations>
-				</local:CustomCSSRule>
 				<local:CustomCSSRule Selector=".terminal">
 					<local:CustomCSSRule.Declarations>
 						<local:CSSDeclaration Attribute="Color" Value="{x:Static platformui:EnvironmentColors.ToolboxContentTextColorKey}" />
@@ -25,6 +20,16 @@
 				<local:CustomCSSRule Selector=".terminal .xterm-viewport">
 					<local:CustomCSSRule.Declarations>
 						<local:CSSDeclaration Attribute="BackgroundColor" Value="{x:Static platformui:EnvironmentColors.ToolboxBackgroundColorKey}" />
+					</local:CustomCSSRule.Declarations>
+				</local:CustomCSSRule>
+				<local:CustomCSSRule Selector=".terminal .xterm-color-15">
+					<local:CustomCSSRule.Declarations>
+						<local:CSSDeclaration Attribute="Color" Value="{x:Static platformui:EnvironmentColors.ToolboxContentTextColorKey}" />
+					</local:CustomCSSRule.Declarations>
+				</local:CustomCSSRule>
+				<local:CustomCSSRule Selector=".terminal .xterm-selection div">
+					<local:CustomCSSRule.Declarations>
+						<local:CSSDeclaration Attribute="BackgroundColor" Value="{x:Static platformui:EnvironmentColors.SystemHighlightColorKey}" />
 					</local:CustomCSSRule.Declarations>
 				</local:CustomCSSRule>
 				<local:CustomCSSRule Selector=".terminal.focus:not(.xterm-cursor-style-underline):not(.xterm-cursor-style-bar) .terminal-cursor">

--- a/EmbeddedTerminal/TermWindowControl.xaml.cs
+++ b/EmbeddedTerminal/TermWindowControl.xaml.cs
@@ -21,7 +21,6 @@
     /// </summary>
     public partial class TermWindowControl : UserControl
     {
-        public static TermWindowPackage Package = null;
         /// <summary>
         /// Initializes a new instance of the <see cref="TermWindowControl"/> class.
         /// </summary>
@@ -86,7 +85,7 @@
 
         public void InitTerm(int cols, int rows, string directory)
         {
-            rpc.InvokeAsync("initTerm", TermWindowControl.Package.OptionTerminal.ToString(), cols, rows, directory);
+            rpc.InvokeAsync("initTerm", TermWindowPackage.Instance?.OptionTerminal.ToString(), cols, rows, directory);
         }
 
         public void ResizeTerm(int cols, int rows)

--- a/EmbeddedTerminal/TermWindowControl.xaml.cs
+++ b/EmbeddedTerminal/TermWindowControl.xaml.cs
@@ -21,6 +21,7 @@
     /// </summary>
     public partial class TermWindowControl : UserControl
     {
+        public static TermWindowPackage Package = null;
         /// <summary>
         /// Initializes a new instance of the <see cref="TermWindowControl"/> class.
         /// </summary>
@@ -28,7 +29,7 @@
         {
             this.InitializeComponent();
 
-
+            
 
             var client = new HubClient();
             var clientStream = client.RequestServiceAsync("wwt.pty").Result;
@@ -85,7 +86,7 @@
 
         public void InitTerm(int cols, int rows, string directory)
         {
-            rpc.InvokeAsync("initTerm", cols, rows, directory);
+            rpc.InvokeAsync("initTerm", TermWindowControl.Package.OptionTerminal.ToString(), cols, rows, directory);
         }
 
         public void ResizeTerm(int cols, int rows)

--- a/EmbeddedTerminal/TermWindowPackage.cs
+++ b/EmbeddedTerminal/TermWindowPackage.cs
@@ -51,8 +51,18 @@ namespace EmbeddedTerminal
         /// </summary>
         protected override void Initialize()
         {
+            TermWindowControl.Package = this;
             TermWindowCommand.Initialize(this);
             base.Initialize();
+        }
+
+        public DefaultTerminal OptionTerminal
+        {
+            get
+            {
+                TerminalOptionPage page = (TerminalOptionPage)GetDialogPage(typeof(TerminalOptionPage));
+                return page.OptionTerminal;
+            }
         }
 
         #endregion

--- a/EmbeddedTerminal/TermWindowPackage.cs
+++ b/EmbeddedTerminal/TermWindowPackage.cs
@@ -51,9 +51,15 @@ namespace EmbeddedTerminal
         /// </summary>
         protected override void Initialize()
         {
-            TermWindowControl.Package = this;
+            TermWindowPackage.Instance = this;
             TermWindowCommand.Initialize(this);
             base.Initialize();
+        }
+
+        public static TermWindowPackage Instance
+        {
+            get;
+            private set;
         }
 
         public DefaultTerminal OptionTerminal
@@ -62,6 +68,15 @@ namespace EmbeddedTerminal
             {
                 TerminalOptionPage page = (TerminalOptionPage)GetDialogPage(typeof(TerminalOptionPage));
                 return page.OptionTerminal;
+            }
+        }
+
+        public string OptionCustomCSSPath
+        {
+            get
+            {
+                TerminalOptionPage page = (TerminalOptionPage)GetDialogPage(typeof(TerminalOptionPage));
+                return page.CustomCSSPath;
             }
         }
 

--- a/EmbeddedTerminal/TermWindowPackage.cs
+++ b/EmbeddedTerminal/TermWindowPackage.cs
@@ -35,6 +35,7 @@ namespace EmbeddedTerminal
     [ProvideToolWindow(typeof(TermWindow))]
     [Guid(TermWindowPackage.PackageGuidString)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
+    [ProvideOptionPage(typeof(TerminalOptionPage), "Whack Whack Terminal", "General", 0, 0, true)]
     public sealed class TermWindowPackage : Package
     {
         /// <summary>

--- a/EmbeddedTerminal/TerminalOptionPage.cs
+++ b/EmbeddedTerminal/TerminalOptionPage.cs
@@ -2,7 +2,9 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -11,6 +13,7 @@ namespace EmbeddedTerminal
     public class TerminalOptionPage : DialogPage
     {
         private DefaultTerminal term = DefaultTerminal.Powershell;
+        string customCSSPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "view\\custom.css").Replace("\\\\", "\\");
 
         [Category("Whack Whack Terminal")]
         [DisplayName("Default Shell")]
@@ -18,6 +21,14 @@ namespace EmbeddedTerminal
         {
             get { return term; }
             set { term = value; }
+        }
+
+        [Category("Whack Whack Terminal")]
+        [DisplayName("Custom CSS File")]
+        public string CustomCSSPath
+        {
+            get { return customCSSPath; }
+            set { customCSSPath = value; }
         }
     }
 
@@ -27,4 +38,5 @@ namespace EmbeddedTerminal
         CMD,
         WSLBash
     }
+
 }

--- a/EmbeddedTerminal/TerminalOptionPage.cs
+++ b/EmbeddedTerminal/TerminalOptionPage.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.VisualStudio.Shell;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EmbeddedTerminal
+{
+    public class TerminalOptionPage : DialogPage
+    {
+        private DefaultTerminal term = DefaultTerminal.Powershell;
+
+        [Category("Whack Whack Terminal")]
+        [DisplayName("Default Shell")]
+        public DefaultTerminal OptionTerminal
+        {
+            get { return term; }
+            set { term = value; }
+        }
+    }
+
+    public enum DefaultTerminal
+    {
+        Powershell,
+        CMD,
+        WSLBash
+    }
+}

--- a/EmbeddedTerminal/service/pty.js
+++ b/EmbeddedTerminal/service/pty.js
@@ -30,8 +30,11 @@ ServicePty.prototype.initTerm = function (shell, cols, rows, startDir) {
         case 'CMD':
             var shelltospawn = cmdPath;
             break;
-        default:
+        case 'WSLBash':
             var shelltospawn = bashPath;
+            break;
+        default:
+            var shelltospawn = powerShellPath;
     }
 
     if (this.ptyConnection != null) {

--- a/EmbeddedTerminal/service/pty.js
+++ b/EmbeddedTerminal/service/pty.js
@@ -13,18 +13,29 @@ function ServicePty(stream, _host) {
     this.connection = rpc.createMessageConnection(new rpc.StreamMessageReader(stream), new rpc.StreamMessageWriter(stream));
     this.ptyConnection = null;
 
-    this.connection.onRequest('initTerm', (cols, rows, start) => this.initTerm(cols, rows, start));
+    this.connection.onRequest('initTerm', (shell, cols, rows, start) => this.initTerm(shell, cols, rows, start));
     this.connection.onRequest('termData', (data) => this.termData(data));
     this.connection.onRequest('resizeTerm', (cols, rows) => this.resizeTerm(cols, rows));
     this.connection.listen();
 }
 
-ServicePty.prototype.initTerm = function (cols, rows, startDir) {
+ServicePty.prototype.initTerm = function (shell, cols, rows, startDir) {
+    switch (shell) {
+        case 'Powershell':
+            var shelltospawn = "powershell.exe";
+            break;
+        case 'CMD':
+            var shelltospawn = "cmd.exe";
+            break;
+        default:
+            var shelltospawn = "C:\\Windows\\sysnative\\bash.exe";
+    }
+
     if (this.ptyConnection != null) {
         this.ptyConnection.destroy();
     }
 
-    this.ptyConnection = pty.spawn(shell, [], {
+    this.ptyConnection = pty.spawn(shelltospawn, [], {
         name: 'vs-integrated-terminal',
         cols: cols,
         rows: rows,

--- a/EmbeddedTerminal/view/custom.css
+++ b/EmbeddedTerminal/view/custom.css
@@ -1,0 +1,39 @@
+﻿/**********************************************************************************************************************
+* This file is provided as an example of how to modify the styling of the terminal. For a full CSS                    *
+* Reference visit https://github.com/sourcelair/xterm.js/blob/2b92996d7c0c8a6f161c90cb96528858979a50fd/src/xterm.css. *
+* Styling that is not set here will be controlled by the extension.                                                   *
+*                                                                                                                     *
+* MODIFYING CSS STYLES OUTSIDE OF COLORS IS ENTIRELY UNSUPPORTED, DO SO AT YOUR OWN RISK                              *
+***********************************************************************************************************************/
+
+
+/* This class controls the default text color of the terminal */
+.terminal {
+	color: default;
+}
+
+	/* Can be used to control the background color of the terminal */
+	.terminal .xterm-viewport {
+		background-color: default;
+	}
+
+	/* This class can be used to modify the color of text selection in the terminal */
+	.terminal .xterm-selection div {
+		background-color: default;
+	}
+
+	/* Modifies the cursor. Note: the background color is the color of the cursor when it is "on" */
+	.terminal.focus:not(.xterm-cursor-style-underline):not(.xterm-cursor-style-bar) .terminal-cursor {
+		background-color: default;
+		color: default;
+	}
+
+	/* Modifies the cursor when the terminal is not focused */
+	.terminal:not(.focus) .terminal-cursor {
+		outline-color: default;
+	}
+
+	/* This class is applied to text elements with the "15" color, xterm supports 256 different color values */
+	.terminal .xterm-color-15 {
+		color: default;
+	}

--- a/EmbeddedTerminal/view/default.css
+++ b/EmbeddedTerminal/view/default.css
@@ -2,34 +2,3 @@
 	height: 100%;
 	margin: 0px;
 }
-
-#content {
-	height: 100%;
-}
-
-
-.terminal {
-	color: white;
-}
-
-	.terminal .xterm-viewport {
-		background-color: black;
-	}
-
-	.terminal .xterm-color-15 {
-		color: white;
-	}
-
-
-	.terminal .xterm-selection div {
-		background-color: #fff;
-	}
-
-	.terminal.focus:not(.xterm-cursor-style-underline):not(.xterm-cursor-style-bar) .terminal-cursor {
-		background-color: #fff;
-		color: #000;
-	}
-
-	.terminal:not(.focus) .terminal-cursor {
-		outline-color: #fff;
-	}


### PR DESCRIPTION
Closes #18, #9, and #8.

Color support was included via a custom CSS file that is editable and settable by the user. While this could be done previously it was unsupported and not guaranteed to work.

The shell selector currently exposes three options, CMD, Powershell and WSL Bash. No checking is currently done to verify if the selected shell is on your system.