### PR TITLE
Add the ability to specify a startup parameter when opening a shell

### DIFF
--- a/EmbeddedTerminal/TermWindowControl.xaml.cs
+++ b/EmbeddedTerminal/TermWindowControl.xaml.cs
@@ -126,7 +126,7 @@
 
         public void InitTerm(int cols, int rows, string directory)
         {
-            rpc.InvokeAsync("initTerm", TermWindowPackage.Instance?.OptionTerminal.ToString(), cols, rows, directory);
+            rpc.InvokeAsync("initTerm", TermWindowPackage.Instance?.OptionTerminal.ToString(), cols, rows, directory, TermWindowPackage.Instance?.OptionStartupArgument);
         }
 
         public void ResizeTerm(int cols, int rows)

--- a/EmbeddedTerminal/TermWindowPackage.cs
+++ b/EmbeddedTerminal/TermWindowPackage.cs
@@ -80,6 +80,15 @@ namespace EmbeddedTerminal
             }
         }
 
+        public string OptionStartupArgument
+        {
+            get
+            {
+                TerminalOptionPage page = (TerminalOptionPage)GetDialogPage(typeof(TerminalOptionPage));
+                return page.StartupArgument;
+            }
+        }
+
         #endregion
     }
 }

--- a/EmbeddedTerminal/TerminalOptionPage.cs
+++ b/EmbeddedTerminal/TerminalOptionPage.cs
@@ -14,6 +14,7 @@ namespace EmbeddedTerminal
     {
         private DefaultTerminal term = DefaultTerminal.Powershell;
         string customCSSPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "view\\custom.css").Replace("\\\\", "\\");
+        string startupArgument = string.Empty;
 
         [Category("Whack Whack Terminal")]
         [DisplayName("Default Shell")]
@@ -29,6 +30,14 @@ namespace EmbeddedTerminal
         {
             get { return customCSSPath; }
             set { customCSSPath = value; }
+        }
+
+        [Category("Whack Whack Terminal")]
+        [DisplayName("Startup Argument")]
+        public string StartupArgument
+        {
+            get { return startupArgument; }
+            set { startupArgument = value; }
         }
     }
 

--- a/EmbeddedTerminal/service/pty.js
+++ b/EmbeddedTerminal/service/pty.js
@@ -16,13 +16,14 @@ function ServicePty(stream, _host) {
     this.connection = rpc.createMessageConnection(new rpc.StreamMessageReader(stream), new rpc.StreamMessageWriter(stream));
     this.ptyConnection = null;
 
-    this.connection.onRequest('initTerm', (shell, cols, rows, start) => this.initTerm(shell, cols, rows, start));
+    this.connection.onRequest('initTerm', (shell, cols, rows, start, argument) => this.initTerm(shell, cols, rows, start, argument));
     this.connection.onRequest('termData', (data) => this.termData(data));
     this.connection.onRequest('resizeTerm', (cols, rows) => this.resizeTerm(cols, rows));
     this.connection.listen();
 }
 
-ServicePty.prototype.initTerm = function (shell, cols, rows, startDir) {
+ServicePty.prototype.initTerm = function (shell, cols, rows, startDir, argument) {
+    var startupArg = ' ' + argument;
     switch (shell) {
         case 'Powershell':
             var shelltospawn = powerShellPath;
@@ -43,7 +44,7 @@ ServicePty.prototype.initTerm = function (shell, cols, rows, startDir) {
         this.ptyConnection.destroy();
     }
 
-    this.ptyConnection = pty.spawn(shelltospawn, [], {
+    this.ptyConnection = pty.spawn(shelltospawn, startupArg, {
         name: 'vs-integrated-terminal',
         cols: cols,
         rows: rows,


### PR DESCRIPTION
Creates a new setting to allow passing a startup parameter. One thing that's missing that I think would be nice is to default the startup param to "-k " for cmd and "-NoExit " for PowerShell as this will be required with the params or the shell will continually restart.