### PR TITLE
pre-compute the font size using a dpi-aware method

### DIFF
--- a/Microsoft.VisualStudio.Terminal/WebView/default.html
+++ b/Microsoft.VisualStudio.Terminal/WebView/default.html
@@ -14,7 +14,7 @@
         requirejs.config({
             paths: {
                 'xterm': '../node_modules/xterm/dist/xterm',
-                'xterm/lib/addons/fit': '../node_modules/xterm/dist/addons/fit/fit'
+                'xterm/lib/addons/fit/fit': '../node_modules/xterm/dist/addons/fit/fit'
             }
         });
 

--- a/Microsoft.VisualStudio.Terminal/WebView/ts/TermView.ts
+++ b/Microsoft.VisualStudio.Terminal/WebView/ts/TermView.ts
@@ -1,5 +1,5 @@
 ﻿import { ITheme, Terminal } from 'xterm';
-import { apply as applyFit } from 'xterm/lib/addons/fit';
+import { apply as applyFit } from 'xterm/lib/addons/fit/fit';
 import { VisualStudio } from './VsEventManager';
 import { registerLocalLinkHandler } from './TerminalLinkMatcher';
 
@@ -87,9 +87,8 @@ export class TermView {
     }
 
     private resizeTerm(size: Geometry) {
-        if (this.term.cols !== size.cols || this.term.rows !== size.rows) {
-            (<any>this.term).renderer.clear();
-            this.term.resize(size.cols, size.rows);
+        if (this.term.cols !== size.cols || this.term.rows !== size.rows) {        
+                this.term.resize(size.cols, size.rows);
         }
     }
 

--- a/Microsoft.VisualStudio.Terminal/WebView/ts/main.ts
+++ b/Microsoft.VisualStudio.Terminal/WebView/ts/main.ts
@@ -8,17 +8,26 @@ triggerEvent = function (event: string, data: any) {
 };
 
 if (document.readyState !== 'loading') {
+    let fontSizeFixingElement = document.createElement('div');
+    fontSizeFixingElement.style.fontSize = `${window.external.GetFontSize()}pt`;
+
+    let fontSize = parseInt(window.getComputedStyle(fontSizeFixingElement).fontSize);
     let termView = new TermView(
         JSON.parse(window.external.GetTheme()),
         window.external.GetFontFamily(),
-        window.external.GetFontSize(),
+        fontSize,
         window.external.GetSolutionDir());
 } else {
     document.addEventListener("DOMContentLoaded", function (event) {
+        let fontSizeFixingElement = document.createElement('div');
+        fontSizeFixingElement.style.fontSize = `${window.external.GetFontSize()}pt`;
+
+        let fontSize = parseInt(window.getComputedStyle(fontSizeFixingElement).fontSize);
+
         let termView = new TermView(
             JSON.parse(window.external.GetTheme()),
             window.external.GetFontFamily(),
-            window.external.GetFontSize(),
+            fontSize,
             window.external.GetSolutionDir());
     });
 }

--- a/Microsoft.VisualStudio.Terminal/package-lock.json
+++ b/Microsoft.VisualStudio.Terminal/package-lock.json
@@ -30,9 +30,9 @@
       "integrity": "sha1-hyOdnhZrLXNSJFuKgTWXgEwdY6o="
     },
     "xterm": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-3.2.0.tgz",
-      "integrity": "sha512-WH1V7eOwybpZoms8zQmMsAVcF3NlW3bVUdftCRt7TYs1E7tYgr59QknJ/pfVqQh5Ao8I8XiPGVKn//6U/yJ9ew=="
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-3.7.0.tgz",
+      "integrity": "sha512-EnWWiVjyN2JMeFYqBAEM3Xe2z61otmArAzKxZMH33IctNGgKL/pbnjZBBWShCroH9KkXAWsHAePzrAURmNu8OQ=="
     }
   }
 }

--- a/Microsoft.VisualStudio.Terminal/package.json
+++ b/Microsoft.VisualStudio.Terminal/package.json
@@ -7,6 +7,6 @@
     "node-pty": "^0.7.2",
     "requirejs": "^2.3.5",
     "vscode-jsonrpc": "^3.5.0",
-    "xterm": "=3.2.0"
+    "xterm": "=3.7.0"
   }
 }


### PR DESCRIPTION
Closes #47 

After digging into this for a long time I finally have a workaround for the DPI issues that have been affecting users. It turns out that WinForms IE11 doesn't set `devicePixelRatio` correctly so the browser can't scale fonts defined with a pixel size (like the fonts in xterm.js). As it turns out though, `getComputedStyle` is DPI aware and can convert point sizes into pixel sizes. By doing this conversion ahead of time a correct font size for the current DPI can be sent to the terminal.